### PR TITLE
🔒 [security fix] Secure Network Security Configuration

### DIFF
--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
+    <!-- Allow cleartext traffic and user CAs for debugging -->
+    <base-config
+        cleartextTrafficPermitted="true"
+        tools:ignore="InsecureBaseConfiguration">
+        <trust-anchors>
+            <!-- Trust preinstalled CAs -->
+            <certificates src="system" />
+
+            <!-- Additionally trust user added CAs for debugging -->
+            <certificates
+                src="user"
+                tools:ignore="AcceptsUserCertificates" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,17 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config xmlns:tools="http://schemas.android.com/tools">
-    <!-- Need to allow cleartext traffic for some sources -->
     <base-config
-        cleartextTrafficPermitted="true"
-        tools:ignore="InsecureBaseConfiguration">
+        cleartextTrafficPermitted="false">
         <trust-anchors>
             <!-- Trust preinstalled CAs -->
             <certificates src="system" />
-
-            <!-- Additionally trust user added CAs -->
-            <certificates
-                src="user"
-                tools:ignore="AcceptsUserCertificates" />
         </trust-anchors>
     </base-config>
 </network-security-config>


### PR DESCRIPTION
🎯 **What:** Fixed an insecure network security configuration that permitted cleartext traffic and trusted user-added CAs in all build variants.

⚠️ **Risk:** Permitting cleartext traffic makes the app vulnerable to Man-in-the-Middle (MITM) attacks. Trusting user-added CAs allows for easy traffic interception and manipulation on compromised or user-controlled devices, potentially exposing sensitive data.

🛡️ **Solution:** Hardened the production (`main`) configuration by disabling cleartext traffic and removing user CA trust. Preserved debugging capabilities by moving the original insecure configuration to a debug-specific resource folder (`src/debug`), which is only used for debug builds.

---
*PR created automatically by Jules for task [16573770214327505100](https://jules.google.com/task/16573770214327505100) started by @Gameaday*